### PR TITLE
Remove DEVELOPMENT from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,7 @@
+# optional - for mysql
 DB_HOST="localhost"
 DB_NAME="dbname"
 DB_USER="root"
 DB_PASSWORD=""
-DEVELOPMENT=true
+
 BASE_URL="http://mywebsite.com"
-MAIL_HOST="example.com"
-MAIL_USER="bob@example.com"
-MAIL_PASSWORD="strongpassword420"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,9 +24,5 @@ jobs:
       - name: Composer install
         run: composer install --prefer-dist --no-progress --no-suggest --dev --optimize-autoloader
 
-      - name: Generate .env
-        run: |
-          echo "DEVELOPMENT=true" > .env
-
       - name: Run PHPUnit
         run: php bin/phpunit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,5 +24,8 @@ jobs:
       - name: Composer install
         run: composer install --prefer-dist --no-progress --no-suggest --dev --optimize-autoloader
 
+      - name: Create empty .env
+        run: echo "" > .env
+
       - name: Run PHPUnit
         run: php bin/phpunit

--- a/app/template/nav.php
+++ b/app/template/nav.php
@@ -7,7 +7,7 @@ $menu = MainMenu::create()
     ->addItem("Documents", "/documents", "fa-file")
 ;
 
-if (env('DEVELOPMENT')) {
+if (is_dev()) {
     $menu->addItem("Dev", "/dev", "fa-code");
 }
 $main_user = User::getMain();

--- a/engine/core/DB.php
+++ b/engine/core/DB.php
@@ -45,7 +45,7 @@ class DB extends SingletonDependency
         $tablePrefix = new \TablePrefix('orm_');
         $evm->addEventListener(\Doctrine\ORM\Events::loadClassMetadata, $tablePrefix);
 
-        $devMode = !!env("DEVELOPMENT");
+        $devMode = !!is_dev();
 
         if ($devMode) {
             $queryCache = new ArrayAdapter();

--- a/engine/core/Router.php
+++ b/engine/core/Router.php
@@ -43,7 +43,7 @@ class Router extends Singleton
         http_response_code($code);
         Page::reset();
         $instance = self::getInstance()->cleanBuffer();
-        if (env('DEVELOPMENT')) {
+        if (is_dev()) {
             echo $message;
         }
         $instance->render();

--- a/engine/helpers.php
+++ b/engine/helpers.php
@@ -165,7 +165,7 @@ function has_session($key): bool
 
 function is_dev()
 {
-    return !!env('DEVELOPMENT');
+    return !env('PRODUCTION');
 }
 
 function restrict_dev()

--- a/engine/load_env.php
+++ b/engine/load_env.php
@@ -9,8 +9,6 @@ if (env("DB_HOST")) {
     $dotenv->required('DB_PASSWORD');
 }
 
-$dotenv->ifPresent('DEVELOPMENT')->isBoolean();
-
 // Mailing - unused at the moment
 // AP 2024-07 - TODO FIXME mailing does not work, we need to plug it into Gmail
 $dotenv->ifPresent('USE_DKIM')->isBoolean();

--- a/engine/setup.php
+++ b/engine/setup.php
@@ -6,7 +6,7 @@ $env = require_once base_path() . "/engine/load_env.php";
 
 // static
 $logger = new \Monolog\Logger('main');
-if (env('DEVELOPMENT')) {
+if (is_dev()) {
     $logger->pushHandler(new \Monolog\Handler\BrowserConsoleHandler(\Monolog\Level::Debug));
 }
 $logger->pushHandler(new \Monolog\Handler\StreamHandler(base_path() . '/logs/app.log'));

--- a/engine/setup.php
+++ b/engine/setup.php
@@ -15,7 +15,7 @@ $logger->pushProcessor(new \Monolog\Processor\WebProcessor());
 
 DB::setupForApp(!env("DB_HOST"));
 MainLogger::instance(new MainLogger($logger));
-Mailer::factory(fn() => (env('DEVELOPMENT') && !env("EMAIL_MOCK_OFF")) || env("EMAIL_MOCK") ? new MockMailer() : new Mailer());
+Mailer::factory(fn() => (is_dev() && !env("EMAIL_MOCK_OFF")) || env("EMAIL_MOCK") ? new MockMailer() : new Mailer());
 
 //services DI
 AuthService::factory(fn() => new AuthService(em()));

--- a/routes.php
+++ b/routes.php
@@ -9,7 +9,7 @@ Router::add('/', 'pages/index');
 Router::add('/login', 'pages/login');
 
 // Developement
-if (env("DEVELOPMENT")) {
+if (is_dev()) {
     Router::add('/dev', 'pages/dev/dev_page');
     Router::add('/dev/create-user', 'pages/dev/create_test_user');
     Router::add('/dev/change-access', 'pages/dev/change_user_access');


### PR DESCRIPTION
I simplify the setup: now the env is dev by default, and we switch it to production if the specific env variable is there in production :D