### PR TITLE
Revert the order of events, add new past_events page

### DIFF
--- a/app/pages/events/event_list/event_list.php
+++ b/app/pages/events/event_list/event_list.php
@@ -55,12 +55,23 @@ page("Événements")->css("event_list.css")
     </a>
 </div>
 
-<?= actions($can_edit)->link(
-    "/evenements/nouveau/choix",
-    "Ajouter un événement",
-    "fas fa-plus",
-    ["data-intro" => 'Créez un événement']
-) ?>
+<?php
+$action = actions();
+if ($can_edit) {
+    $action->link(
+        "/evenements/nouveau/choix",
+        "Ajouter un événement",
+        "fas fa-plus",
+        ["data-intro" => 'Créez un événement']
+    );
+}
+$action->link(
+    "/evenements/passes",
+    "Évenements passés",
+    "fa-clock-rotate-left",
+)
+    ?>
+<?= $action ?>
 
 <?php if (!count($future_events) && !($can_edit && count($draft_events))): ?>
     <p class="center">Pas d'événement pour le moment 😴</p>
@@ -81,11 +92,4 @@ if ($can_edit && count($draft_events)): ?>
     <?php foreach ($future_events as $event): ?>
         <?= render_events($event); ?>
     <?php endforeach ?>
-</div>
-
-<div id="loadEvents">
-    <button class="outline secondary" hx-get="/evenements/passes" hx-swap="outerHTML" hx-target="this">Charger
-        les
-        événements
-        passés</button>
 </div>

--- a/app/pages/events/event_list/past_events.php
+++ b/app/pages/events/event_list/past_events.php
@@ -4,15 +4,36 @@ include_once __DIR__ . "/RenderEvents.php";
 restrict_access();
 formatter("d MMM");
 $user = User::getCurrent();
-$past_events = EventService::listAllPastOpen($user->id);
 
+// Pagination parameters
+$page_param = get_query_param('page');
+$page = isset($page_param) ? (int) $page_param : 1;
+$limit = 100;
+$offset = ($page - 1) * $limit;
+
+// Fetch paginated events
+$past_events = EventService::listPastOpenPaginated($user->id, $limit, $offset);
+$has_more = count($past_events) === $limit;
+
+if ($page === 1) {
+    page("Évenements passés")->css("event_list.css");
+}
 ?>
-<h4>Évenements passés</h4>
+<?php if ($page === 1): ?>
+    <?= actions()->back("/evenements"); ?>
+<?php endif; ?>
+
 <?php
 if (count($past_events)) {
     foreach ($past_events as $event) {
         render_events($event);
     }
-} else { ?>
-    <p>Pas d'événements passés 😿</p>
-<?php }
+} else if ($page === 1) { ?>
+        <p>Pas d'événements passés 😿</p>
+<?php } ?>
+
+<?php if ($has_more): ?>
+    <div id="load-more-trigger" hx-get="/evenements/passes?page=<?= $page + 1 ?>" hx-trigger="revealed" hx-swap="outerHTML">
+        <p class="center"><i class="fas fa-spinner fa-spin"></i> Chargement...</p>
+    </div>
+<?php endif; ?>

--- a/app/pages/events/view/event_view.php
+++ b/app/pages/events/view/event_view.php
@@ -17,12 +17,14 @@ $entry = $event->entries->get(0) ?? null;
 $totalEntryCount = EventService::getEntryCount($event->id);
 $is_simple = $event->type == EventType::Simple;
 
+$today = date_create("today");
+
 page($event->name)->css("event_view.css")->css("entry_list.css")->script("select-table.js")->script("copy-entry-emails.js")->enableHelp();
 ?>
 <script src="/assets/js/start-intro.js"></script>
 
 <?= actions()
-    ->back("/evenements")
+    ->back($event->start_date >= $today_date ? "/evenements" : "/evenements/passes")
     ->if($can_edit, fn($b) => $b->dropdown(function ($dropdown) use ($event, $is_simple) {
         $dropdown->link("/evenements/$event->id/modifier" . ($is_simple ? "/simple" : "/complexe"), "Éditer", "fa-pen", ["class" => "secondary"]);
         $dropdown->link("/evenements/$event->id/rappel", "Rappel", "fa-bell", ["class" => "secondary"]);

--- a/app/services/EventService.php
+++ b/app/services/EventService.php
@@ -64,7 +64,7 @@ class EventService
                 " LEFT JOIN ev.entries en WITH en.user = ?1" .
                 " WHERE ev.open = 1" .
                 " AND ev.end_date > CURRENT_DATE()" .
-                " ORDER BY ev.start_date DESC")
+                " ORDER BY ev.start_date ASC")
             ->setParameter(1, $user_id)
             ->getArrayResult();
 
@@ -76,7 +76,7 @@ class EventService
         $events = em()
             ->createQuery("SELECT ev.id, ev.name, ev.start_date, ev.end_date, ev.deadline, ev.open FROM Event ev" .
                 " WHERE ev.open = 0" .
-                " ORDER BY ev.start_date DESC")
+                " ORDER BY ev.start_date ASC")
             ->getArrayResult();
         return EventDto::fromEventList($events);
     }
@@ -91,6 +91,23 @@ class EventService
                 " AND ev.end_date <= CURRENT_DATE()" .
                 " ORDER BY ev.start_date DESC")
             ->setParameter(1, $user_id)
+            ->getArrayResult();
+
+        return EventDto::fromEventList($events);
+    }
+
+    /** @return EventDto[] */
+    static function listPastOpenPaginated($user_id, $limit, $offset)
+    {
+        $events = em()
+            ->createQuery("SELECT ev.id, ev.name, ev.start_date, ev.end_date, ev.deadline, ev.open, en.present FROM Event ev" .
+                " LEFT JOIN ev.entries en WITH en.user = ?1" .
+                " WHERE ev.open = 1" .
+                " AND ev.end_date <= CURRENT_DATE()" .
+                " ORDER BY ev.start_date DESC")
+            ->setParameter(1, $user_id)
+            ->setMaxResults($limit)
+            ->setFirstResult($offset)
             ->getArrayResult();
 
         return EventDto::fromEventList($events);


### PR DESCRIPTION
There was a need from raidlinks to have the order reverted : have the next event on top of the list. So to make it logical, reverted all and create a new page for past events to make it cleaner.